### PR TITLE
Option to pull metashape run name from config filename

### DIFF
--- a/R/create_derived_configs.R
+++ b/R/create_derived_configs.R
@@ -23,7 +23,7 @@ create_derived_configs = function(base_cfg_path, save_dir, replacements) {
     base_config = read_yaml(base_cfg_path)
     
     # Create output dir
-    if(!dir.exists(save_dir)) dir.create(save_dir)
+    if(!dir.exists(save_dir)) dir.create(save_dir, recursive = TRUE)
     
     
     #### Run

--- a/config/base.yml
+++ b/config/base.yml
@@ -19,6 +19,7 @@ output_path: "/example/output/path"
 project_path: "/example/project/path"
 
 # The identifier for the run. Will be used in naming output files. Recommended to include a photoset name and processing parameter set name.
+# Optionally, set it to "from_config_filename" to use the config file name (minus extension) as the run name
 run_name: "example-run-001"
 
 # CRS EPSG code that project outputs should be in (projection should be in meter units and intended for the project area)

--- a/config/example.yml
+++ b/config/example.yml
@@ -19,6 +19,7 @@ output_path: "/example/output/path"
 project_path: "/example/project/path"
 
 # The identifier for the run. Will be used in naming output files. Recommended to include a photoset name and processing parameter set name.
+# Optionally, set it to "from_config_filename" to use the config file name (minus extension) as the run name
 run_name: "example-run-001"
 
 # CRS EPSG code that project outputs should be in (projection should be in meter units and intended for the project area)

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -32,7 +32,7 @@ cfg = read_yaml.read_yaml(config_file)
 
 ### Run the Metashape workflow
 
-doc, log, run_id = meta.project_setup(cfg)
+doc, log, run_id = meta.project_setup(cfg, config_file)
 
 meta.enable_and_log_gpu(log, cfg)
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -56,10 +56,10 @@ def get_camera(chunk, label):
 
 #### Functions for each major step in Metashape
 
-def project_setup(cfg):
+def project_setup(cfg, config_file):
     '''
     Create output and project paths, if they don't exist
-    Define a project ID based on photoset name and timestamp
+    Define a project ID based on specified project name and timestamp
     Define a project filename and a log filename
     Create the project
     Start a log file
@@ -71,10 +71,14 @@ def project_setup(cfg):
     if not os.path.exists(cfg["project_path"]):
         os.makedirs(cfg["project_path"])
 
-    ### Set a filename template for project files and output files
-    ## Get the first parts of the filename (the photoset ID and location string)
+    ### Set a filename template for project files and output files based on the 'run_name' key of the config YML
+    ## BUT if the value for run_name is "from_config_filename", then use the config filename for the run name.
 
     run_name = cfg["run_name"]
+
+    if(run_name == "from_config_filename"):
+        file_basename = os.path.basename(config_file) # extracts file base name from path
+        run_name, _ = os.path.splitext(file_basename) # removes extension
 
     ## Project file example to make: "projectID_YYYYMMDDtHHMM-jobID.psx"
     timestamp = stamp_time()


### PR DESCRIPTION
This addresses #2 . The `run_name` is a parameter specified in the config YAML for the metashape run. Now, if `run_name` is set to `from_config_filename`, it will use the filename of the config file instead.