### PR TITLE
Add model building functionality and camera & model exports

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -143,8 +143,8 @@ buildOrthomosaic: # (Metashape: buildOrthomosaic, exportRaster)
 
 buildModel:
     enabled: True
-    face_count: "high" # How many faces to use, low, medium, high, custom
-    face_count_custom: 100000 # Only used if custom number of faces set. TODO how to default?
+    face_count: "Metashape.HighFaceCount" # How many faces to use, Metashape.LowFaceCount, MediumFaceCount, HighFaceCount, CustomFaceCount
+    face_count_custom: 100000 # Only used if custom number of faces set (above).
     reset_alignment: False # Reset the alignment to identity, this is necessary for aligning with the cameras but breaks geospatial referencing for the chunk
     export: True
     export_extension: "ply" # Can be any supported 3D model extension

--- a/config/base.yml
+++ b/config/base.yml
@@ -83,7 +83,14 @@ optimizeCameras: # (Metashape: optimizeCameras)
     enabled: True
     adaptive_fitting: True # Should the camera lens model be fit at the same time as optimizing photos?
 
-buildPointCloud: # (Metashape: buildDepthMaps, buildPointCloud, (optionally) classifyGroundPoints, and exportPoints)
+buildDepthMap: # (Metashape: buildDepthMaps)
+    enabled: True
+    downscale: 2 # How much to coarsen the photos when searching for matches to build the point cloud. For large photosets, values < 4 likely take prohibitively long. Accepts numbers 2^x (https://www.agisoft.com/forum/index.php?topic=11697.0).
+    filter_mode: Metashape.ModerateFiltering # How to filter the point cloud. Options are NoFiltering, MildFiltering, ModerateFiltering, AggressiveFiltering. Aggressive filtering removes detail and makes worse DEMs (at least for forest). NoFiltering takes very long. In trials, it never completed.
+    reuse_depth: False # Purpose unknown.
+    max_neighbors: 100 # Maximum number of neighboring photos to use for estimating point cloud. Higher numbers may increase accuracy but dramatically increase processing time.
+
+buildPointCloud: # (Metashape: buildPointCloud, (optionally) classifyGroundPoints, and exportPoints)
     enabled: True
     ## For depth maps (buildDepthMaps)
     downscale: 2 # How much to coarsen the photos when searching for matches to build the point cloud. For large photosets, values < 4 likely take prohibitively long. Accepts numbers 2^x (https://www.agisoft.com/forum/index.php?topic=11697.0).
@@ -135,6 +142,8 @@ buildOrthomosaic: # (Metashape: buildOrthomosaic, exportRaster)
 buildModel:
     enabled: True
     face_count: "high" # How many faces to use, low, medium, high, custom
-    custom_face_count: 100000 # Only used if custom number of faces set
+    face_count_custom: 100000 # Only used if custom number of faces set. TODO how to default?
+    reset_alignment: False # Reset the alignment to identity, this is necessary for aligning with the cameras but breaks geospatial referencing for the chunk
     export: True
- 
+    export_extension: "ply" # Can be any supported 3D model extension
+

--- a/config/base.yml
+++ b/config/base.yml
@@ -131,3 +131,10 @@ buildOrthomosaic: # (Metashape: buildOrthomosaic, exportRaster)
     tiff_tiled: False # Use tiled TIFF? This is related to internal file architecture.
     nodata: -32767 # Value used to represent nodata.
     tiff_overviews: True # Include coarse-scale raster data in file for quick display in GIS.
+
+buildModel:
+    enabled: True
+    face_count: "high" # How many faces to use, low, medium, high, custom
+    custom_face_count: 100000 # Only used if custom number of faces set
+    export: True
+ 

--- a/config/base.yml
+++ b/config/base.yml
@@ -60,7 +60,7 @@ calibrateReflectance: # (Metahsape: calibrateReflectance)
     use_reflectance_panels: True
     use_sun_sensor: True
 
-alignPhotos: # (Metashape: matchPhotos, alignCameras)
+alignPhotos: # (Metashape: matchPhotos, alignCameras, (optionally) exportCameras)
     enabled: True
     downscale: 2 # How much to coarsen the photos when searching for tie points. Higher number for blurrier photos or when there are small surfaces that may move between photos (such as leaves). Accepts numbers 2^x (and zero) (https://www.agisoft.com/forum/index.php?topic=11697.0).
     adaptive_fitting: True # Should the camera lens model be fit at the same time as aligning photos?
@@ -69,6 +69,7 @@ alignPhotos: # (Metashape: matchPhotos, alignCameras)
     generic_preselection: True # When matching photos, use a much-coarsened version of each photo to narrow down the potential neighbors to pair? Works well if the photos have high altitude above the surface and high overlap (e.g. a 120m nadir 90/90 overlap mission), but doesn't work well for low-altitude and/or highly oblique photos (e.g. a 80m 25deg pitch 80/80 overlap mission)
     reference_preselection: True # When matching photos, use the camera location data to narrow down the potential neighbors to pair?
     reference_preselection_mode: Metashape.ReferencePreselectionSource # When matching photos, use the camera location data to narrow down the potential neighbors to pair?
+    export: True # Export the camera locations
 
 filterPointsUSGS:
     enabled: False
@@ -82,6 +83,7 @@ filterPointsUSGS:
 optimizeCameras: # (Metashape: optimizeCameras)
     enabled: True
     adaptive_fitting: True # Should the camera lens model be fit at the same time as optimizing photos?
+    export: True # Export the camera locations, now updated from the initial alignment
 
 buildDepthMap: # (Metashape: buildDepthMaps)
     enabled: True

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -71,6 +71,9 @@ if cfg["buildDem"]["enabled"]:
 if cfg["buildOrthomosaic"]["enabled"]:
     meta.build_orthomosaics(doc, log, run_id, cfg)
 
+if cfg["buildModel"]["enabled"]:
+    meta.build_model(doc, log, run_id, cfg)
+
 meta.export_report(doc, run_id, cfg)
 
 meta.finish_run(log, config_file)

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -62,17 +62,20 @@ if cfg["filterPointsUSGS"]["enabled"]:
     meta.filter_points_usgs_part2(doc, cfg)
     meta.reset_region(doc)
 
+if cfg["buildDepthMap"]["enabled"]:
+    meta.build_depth_map(doc, log, cfg)
+
 if cfg["buildPointCloud"]["enabled"]:
     meta.build_point_cloud(doc, log, run_id, cfg)
+
+if cfg["buildModel"]["enabled"]:
+    meta.build_model(doc, log, run_id, cfg)
 
 if cfg["buildDem"]["enabled"]:
     meta.build_dem(doc, log, run_id, cfg)
 
 if cfg["buildOrthomosaic"]["enabled"]:
     meta.build_orthomosaics(doc, log, run_id, cfg)
-
-if cfg["buildModel"]["enabled"]:
-    meta.build_model(doc, log, run_id, cfg)
 
 meta.export_report(doc, run_id, cfg)
 

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -43,7 +43,7 @@ if cfg["calibrateReflectance"]["enabled"]:
     meta.calibrate_reflectance(doc, cfg)
 
 if cfg["alignPhotos"]["enabled"]:
-    meta.align_photos(doc, log, cfg)
+    meta.align_photos(doc, log, run_id, cfg)
     meta.reset_region(doc)
 
 if cfg["filterPointsUSGS"]["enabled"]:
@@ -55,7 +55,7 @@ if cfg["addGCPs"]["enabled"]:
     meta.reset_region(doc)
 
 if cfg["optimizeCameras"]["enabled"]:
-    meta.optimize_cameras(doc, cfg)
+    meta.optimize_cameras(doc, run_id, cfg)
     meta.reset_region(doc)
 
 if cfg["filterPointsUSGS"]["enabled"]:

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -22,7 +22,7 @@ except:  # running from command line (in linux) or interactively (windows)
     import metashape_workflow_functions as meta
     import read_yaml
 
-if(sys.stdin.isatty()):
+if sys.stdin.isatty():
     config_file = sys.argv[1]
 else:
     config_file = manual_config_file

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -641,40 +641,23 @@ def build_model(doc, log_file, run_id, cfg):
     Build and export the model
     """
 
-    """
-    buildModel(surface_type=Arbitrary, interpolation=EnabledInterpolation, face_count=HighFaceCount,
-        face_count_custom=200000, source_data=DepthMapsData[, classes], vertex_colors=True,
-        vertex_confidence=True, volumetric_masks=False, keep_depth=True, trimming_radius=10[,
-        cameras], subdivide_task=True, workitem_size_cameras=20, max_workgroup_size=100[,
-        progress])
-    """
-    # Choose the enum for the quality
-    face_count_dict = {
-        "low": Metashape.LowFaceCount,
-        "medium": Metashape.MediumFaceCount,
-        "high": Metashape.HighFaceCount,
-        "custom": Metashape.CustomFaceCount,
-    }
-    face_count = face_count_dict[cfg["buildModel"]["face_count"]]
-
     start_time = time.time()
     # Build the mesh
     doc.chunk.buildModel(
         surface_type=Metashape.Arbitrary,
         interpolation=Metashape.EnabledInterpolation,
-        face_count=face_count,
+        face_count=cfg["buildModel"]["face_count"],
         face_count_custom=cfg["buildModel"][
             "face_count_custom"
         ],  # Only used if face_count is custom
         source_data=Metashape.DepthMapsData,
     )
 
-    if cfg["buildModel"]["reset_alignment"]
+    if cfg["buildModel"]["reset_alignment"]:
         # This is required for alignment with the cameras
         # The approach was recommended here: https://www.agisoft.com/forum/index.php?topic=8210.0
         doc.chunk.crs = None
         doc.chunk.transform.matrix = None
-
 
     if cfg["buildModel"]["export"]:
         output_file = os.path.join(

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -531,6 +531,49 @@ def build_point_cloud(doc, log_file, run_id, cfg):
 
 
 
+def build_model(doc, log_file, run_id, cfg):
+    '''
+    Build and export the model
+    '''
+
+    """
+    buildModel(surface_type=Arbitrary, interpolation=EnabledInterpolation, face_count=HighFaceCount,
+        face_count_custom=200000, source_data=DepthMapsData[, classes], vertex_colors=True,
+        vertex_confidence=True, volumetric_masks=False, keep_depth=True, trimming_radius=10[,
+        cameras], subdivide_task=True, workitem_size_cameras=20, max_workgroup_size=100[,
+        progress])
+    """
+    # Choose the enum for the quality
+    face_count_dict = {
+                        "low": PhotoScan.LowFaceCount,
+                        "medium": PhotoScan.MediumFaceCount,
+                        "high": PhotoScan.HighFaceCount,
+                        "custom": PhotoScan.CustomFaceCount,
+                       }
+    face_count = face_count_dict[cfg["buildModel"]["face_count"]]
+
+    start_time = time.time()
+    # Build the mesh
+    doc.chunk.buildModel(surface = PhotoScan.Arbitrary,
+                         interpolation = PhotoScan.EnabledInterpolation,
+                         face_count = face_count,
+                         face_count_custom = cfg["buildModel"]["face_count_custom"], # Only used if face_count is custom
+                         source = PhotoScan.DepthMapsData)
+    # Save the model
+    doc.save()
+
+    if cfg["buildModel"]["export"]:
+        output_file = os.path.join(cfg["output_path"], run_id + '_model.obj')
+        doc.chunk.exportModel(path=output_file)
+
+    time_taken = diff_time(start_time, time.time())
+
+    # record results to file
+    with open(log_file, 'a') as file:
+        file.write(sep.join(['Build Model', time_taken]) + '\n')
+
+    return True
+
 
 def build_dem(doc, log_file, run_id, cfg):
     '''

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -24,19 +24,22 @@ import Metashape
 # TODO: Consider moving log to json/yaml formatting using a dict
 sep = "; "
 
+
 def stamp_time():
-    '''
+    """
     Format the timestamps as needed
-    '''
-    stamp = datetime.datetime.now().strftime('%Y%m%dT%H%M')
+    """
+    stamp = datetime.datetime.now().strftime("%Y%m%dT%H%M")
     return stamp
 
+
 def diff_time(t2, t1):
-    '''
+    """
     Give a end and start time, subtract, and round
-    '''
-    total = str(round(t2-t1, 1))
+    """
+    total = str(round(t2 - t1, 1))
     return total
+
 
 # Used by add_gcps function
 def get_marker(chunk, label):
@@ -44,6 +47,7 @@ def get_marker(chunk, label):
         if marker.label == label:
             return marker
     return None
+
 
 # Used by add_gcps function
 def get_camera(chunk, label):
@@ -53,17 +57,17 @@ def get_camera(chunk, label):
     return None
 
 
-
 #### Functions for each major step in Metashape
 
+
 def project_setup(cfg, config_file):
-    '''
+    """
     Create output and project paths, if they don't exist
     Define a project ID based on specified project name and timestamp
     Define a project filename and a log filename
     Create the project
     Start a log file
-    '''
+    """
 
     # Make project directories (necessary even if loading an existing project because this workflow saves a new project based on the old one, leaving the old one intact
     if not os.path.exists(cfg["output_path"]):
@@ -76,25 +80,28 @@ def project_setup(cfg, config_file):
 
     run_name = cfg["run_name"]
 
-    if(run_name == "from_config_filename"):
-        file_basename = os.path.basename(config_file) # extracts file base name from path
-        run_name, _ = os.path.splitext(file_basename) # removes extension
+    if run_name == "from_config_filename":
+        file_basename = os.path.basename(
+            config_file
+        )  # extracts file base name from path
+        run_name, _ = os.path.splitext(file_basename)  # removes extension
 
     ## Project file example to make: "projectID_YYYYMMDDtHHMM-jobID.psx"
     timestamp = stamp_time()
-    run_id = "_".join([run_name,timestamp])
+    run_id = "_".join([run_name, timestamp])
     # TODO: If there is a slurm JobID, append to time (separated with "-", not "_"). This will keep jobs initiated in the same minute distinct
 
-    project_file = os.path.join(cfg["project_path"], '.'.join([run_id, 'psx']) )
-    log_file = os.path.join(cfg["output_path"], '.'.join([run_id+"_log",'txt']) )
+    project_file = os.path.join(cfg["project_path"], ".".join([run_id, "psx"]))
+    log_file = os.path.join(cfg["output_path"], ".".join([run_id + "_log", "txt"]))
 
-
-    '''
+    """
     Create a doc and a chunk
-    '''
+    """
 
     # create a handle to the Metashape object
-    doc = Metashape.Document() #When running via Metashape, can use: doc = Metashape.app.document
+    doc = (
+        Metashape.Document()
+    )  # When running via Metashape, can use: doc = Metashape.app.document
 
     # If specified, open existing project
     if cfg["load_project"] != "":
@@ -108,60 +115,64 @@ def project_setup(cfg, config_file):
     # Save doc doc as new project (even if we opened an existing project, save as a separate one so the existing project remains accessible in its original state)
     doc.save(project_file)
 
-
-    '''
+    """
     Log specs except for GPU
-    '''
+    """
 
     # log Metashape version, CPU specs, time, and project location to results file
     # open the results file
     # TODO: records the Slurm values for actual cpus and ram allocated
     # https://slurm.schedmd.com/sbatch.html#lbAI
-    with open(log_file, 'a') as file:
+    with open(log_file, "a") as file:
 
         # write a line with the Metashape version
-        file.write(sep.join(['Project', run_id])+'\n')
-        file.write(sep.join(['Agisoft Metashape Professional Version', Metashape.app.version])+'\n')
+        file.write(sep.join(["Project", run_id]) + "\n")
+        file.write(
+            sep.join(["Agisoft Metashape Professional Version", Metashape.app.version])
+            + "\n"
+        )
         # write a line with the date and time
-        file.write(sep.join(['Processing started', stamp_time()]) +'\n')
+        file.write(sep.join(["Processing started", stamp_time()]) + "\n")
         # write a line with CPU info - if possible, improve the way the CPU info is found / recorded
-        file.write(sep.join(['Node', platform.node()])+'\n')
-        file.write(sep.join(['CPU', platform.processor()]) +'\n')
+        file.write(sep.join(["Node", platform.node()]) + "\n")
+        file.write(sep.join(["CPU", platform.processor()]) + "\n")
         # write two lines with GPU info: count and model names - this takes multiple steps to make it look clean in the end
 
     return doc, log_file, run_id
 
 
-
 def enable_and_log_gpu(log_file, cfg):
-    '''
+    """
     Enables GPU and logs GPU specs
-    '''
+    """
 
     gpustringraw = str(Metashape.app.enumGPUDevices())
     gpucount = gpustringraw.count("name': '")
-    gpustring = ''
+    gpustring = ""
     currentgpu = 1
     while gpucount >= currentgpu:
-        if gpustring != '': gpustring = gpustring+', '
-        gpustring = gpustring+gpustringraw.split("name': '")[currentgpu].split("',")[0]
-        currentgpu = currentgpu+1
-    #gpustring = gpustringraw.split("name': '")[1].split("',")[0]
+        if gpustring != "":
+            gpustring = gpustring + ", "
+        gpustring = (
+            gpustring + gpustringraw.split("name': '")[currentgpu].split("',")[0]
+        )
+        currentgpu = currentgpu + 1
+    # gpustring = gpustringraw.split("name': '")[1].split("',")[0]
     gpu_mask = Metashape.app.gpu_mask
 
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Number of GPUs Found', str(gpucount)]) +'\n')
-        file.write(sep.join(['GPU Model', gpustring])+'\n')
-        file.write(sep.join(['GPU Mask', str(gpu_mask)])+'\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Number of GPUs Found", str(gpucount)]) + "\n")
+        file.write(sep.join(["GPU Model", gpustring]) + "\n")
+        file.write(sep.join(["GPU Mask", str(gpu_mask)]) + "\n")
 
         # If a GPU exists but is not enabled, enable the 1st one
         if (gpucount > 0) and (gpu_mask == 0):
             Metashape.app.gpu_mask = 1
             gpu_mask = Metashape.app.gpu_mask
-            file.write(sep.join(['GPU Mask Enabled', str(gpu_mask)])+'\n')
+            file.write(sep.join(["GPU Mask Enabled", str(gpu_mask)]) + "\n")
 
         # This writes down all the GPU devices available
-        #file.write('GPU(s): '+str(Metashape.app.enumGPUDevices())+'\n')
+        # file.write('GPU(s): '+str(Metashape.app.enumGPUDevices())+'\n')
 
     # set Metashape to *not* use the CPU during GPU steps (appears to be standard wisdom)
     Metashape.app.cpu_enable = False
@@ -171,49 +182,73 @@ def enable_and_log_gpu(log_file, cfg):
         Metashape.app.settings.setValue("main/gpu_enable_cuda", "0")
 
     # Set GPU multiplier to value specified (2 is default)
-    Metashape.app.settings.setValue("main/depth_max_gpu_multiplier", cfg["gpu_multiplier"])
+    Metashape.app.settings.setValue(
+        "main/depth_max_gpu_multiplier", cfg["gpu_multiplier"]
+    )
 
     return True
 
 
 def add_photos(doc, cfg):
-    '''
+    """
     Add photos to project and change their labels to include their containing folder
-    '''
+    """
 
     ## Get paths to all the project photos
-    a = glob.iglob(os.path.join(cfg["photo_path"],"**","*.*"), recursive=True)   #(([jJ][pP][gG])|([tT][iI][fF]))
+    a = glob.iglob(
+        os.path.join(cfg["photo_path"], "**", "*.*"), recursive=True
+    )  # (([jJ][pP][gG])|([tT][iI][fF]))
     b = [path for path in a]
-    photo_files = [x for x in b if (re.search("(.tif$)|(.jpg$)|(.TIF$)|(.JPG$)",x) and (not re.search("dem_usgs.tif",x)))]
-
+    photo_files = [
+        x
+        for x in b
+        if (
+            re.search("(.tif$)|(.jpg$)|(.TIF$)|(.JPG$)", x)
+            and (not re.search("dem_usgs.tif", x))
+        )
+    ]
 
     ## Add them
     if cfg["multispectral"]:
-        doc.chunk.addPhotos(photo_files, layout = Metashape.MultiplaneLayout)
+        doc.chunk.addPhotos(photo_files, layout=Metashape.MultiplaneLayout)
     else:
         doc.chunk.addPhotos(photo_files)
-
 
     ## Need to change the label on each camera so that it includes the containing folder(S)
     for camera in doc.chunk.cameras:
         path = camera.photo.path
         # remove the base imagery dir from this string
-        rel_path = path.replace(cfg["photo_path"],"")
+        rel_path = path.replace(cfg["photo_path"], "")
         # if it starts with a '/', remove it
-        newlabel = re.sub("^/","",rel_path)
+        newlabel = re.sub("^/", "", rel_path)
         camera.label = newlabel
 
     ## If specified, change the accuracy of the cameras to match the RTK flag (RTK fix if flag = 50, otherwise no fix
     if cfg["use_rtk"]:
         for cam in doc.chunk.cameras:
-            rtkflag = cam.photo.meta['DJI/RtkFlag']
-            if rtkflag == '50':
-                cam.reference.location_accuracy = Metashape.Vector([cfg["fix_accuracy"],cfg["fix_accuracy"],cfg["fix_accuracy"]])
-                cam.reference.accuracy = Metashape.Vector([cfg["fix_accuracy"],cfg["fix_accuracy"],cfg["fix_accuracy"]])
+            rtkflag = cam.photo.meta["DJI/RtkFlag"]
+            if rtkflag == "50":
+                cam.reference.location_accuracy = Metashape.Vector(
+                    [cfg["fix_accuracy"], cfg["fix_accuracy"], cfg["fix_accuracy"]]
+                )
+                cam.reference.accuracy = Metashape.Vector(
+                    [cfg["fix_accuracy"], cfg["fix_accuracy"], cfg["fix_accuracy"]]
+                )
             else:
-                cam.reference.location_accuracy = Metashape.Vector([cfg["nofix_accuracy"],cfg["nofix_accuracy"],cfg["nofix_accuracy"]])
-                cam.reference.accuracy = Metashape.Vector([cfg["nofix_accuracy"],cfg["nofix_accuracy"],cfg["nofix_accuracy"]])
-
+                cam.reference.location_accuracy = Metashape.Vector(
+                    [
+                        cfg["nofix_accuracy"],
+                        cfg["nofix_accuracy"],
+                        cfg["nofix_accuracy"],
+                    ]
+                )
+                cam.reference.accuracy = Metashape.Vector(
+                    [
+                        cfg["nofix_accuracy"],
+                        cfg["nofix_accuracy"],
+                        cfg["nofix_accuracy"],
+                    ]
+                )
 
     doc.save()
 
@@ -223,31 +258,47 @@ def add_photos(doc, cfg):
 def calibrate_reflectance(doc, cfg):
     # TODO: Handle failure to find panels, or mulitple panel images by returning error to user.
     doc.chunk.locateReflectancePanels()
-    doc.chunk.loadReflectancePanelCalibration(os.path.join(cfg["photo_path"],"calibration",cfg["calibrateReflectance"]["panel_filename"]))
+    doc.chunk.loadReflectancePanelCalibration(
+        os.path.join(
+            cfg["photo_path"],
+            "calibration",
+            cfg["calibrateReflectance"]["panel_filename"],
+        )
+    )
     # doc.chunk.calibrateReflectance(use_reflectance_panels=True,use_sun_sensor=True)
-    doc.chunk.calibrateReflectance(use_reflectance_panels=cfg["calibrateReflectance"]["use_reflectance_panels"],
-                                   use_sun_sensor=cfg["calibrateReflectance"]["use_sun_sensor"])
+    doc.chunk.calibrateReflectance(
+        use_reflectance_panels=cfg["calibrateReflectance"]["use_reflectance_panels"],
+        use_sun_sensor=cfg["calibrateReflectance"]["use_sun_sensor"],
+    )
     doc.save()
 
     return True
 
 
 def add_gcps(doc, cfg):
-    '''
+    """
     Add GCPs (GCP coordinates and the locations of GCPs in individual photos.
     See the helper script (and the comments therein) for details on how to prepare the data needed by this function: R/prep_gcps.R
-    '''
+    """
 
     ## Tag specific pixels in specific images where GCPs are located
-    path = os.path.join(cfg["photo_path"], "gcps", "prepared", "gcp_imagecoords_table.csv")
+    path = os.path.join(
+        cfg["photo_path"], "gcps", "prepared", "gcp_imagecoords_table.csv"
+    )
     file = open(path)
     content = file.read().splitlines()
 
     for line in content:
         marker_label, camera_label, x_proj, y_proj = line.split(",")
-        if marker_label[0] == '"': # if it's in quotes (from saving CSV in Excel), remove quotes
-            marker_label = marker_label[1:-1]  # need to get it out of the two pairs of quotes
-        if camera_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
+        if (
+            marker_label[0] == '"'
+        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
+            marker_label = marker_label[
+                1:-1
+            ]  # need to get it out of the two pairs of quotes
+        if (
+            camera_label[0] == '"'
+        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
             camera_label = camera_label[1:-1]
 
         marker = get_marker(doc.chunk, marker_label)
@@ -260,8 +311,9 @@ def add_gcps(doc, cfg):
             print(camera_label + " camera not found in project")
             continue
 
-        marker.projections[camera] = Metashape.Marker.Projection((float(x_proj), float(y_proj)), True)
-
+        marker.projections[camera] = Metashape.Marker.Projection(
+            (float(x_proj), float(y_proj)), True
+        )
 
     ## Assign real-world coordinates to each GCP
     path = os.path.join(cfg["photo_path"], "gcps", "prepared", "gcp_table.csv")
@@ -271,8 +323,12 @@ def add_gcps(doc, cfg):
 
     for line in content:
         marker_label, world_x, world_y, world_z = line.split(",")
-        if marker_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
-            marker_label = marker_label[1:-1]  # need to get it out of the two pairs of quotes
+        if (
+            marker_label[0] == '"'
+        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
+            marker_label = marker_label[
+                1:-1
+            ]  # need to get it out of the two pairs of quotes
 
         marker = get_marker(doc.chunk, marker_label)
         if not marker:
@@ -280,9 +336,17 @@ def add_gcps(doc, cfg):
             marker.label = marker_label
 
         marker.reference.location = (float(world_x), float(world_y), float(world_z))
-        marker.reference.accuracy = (cfg["addGCPs"]["marker_location_accuracy"], cfg["addGCPs"]["marker_location_accuracy"], cfg["addGCPs"]["marker_location_accuracy"])
+        marker.reference.accuracy = (
+            cfg["addGCPs"]["marker_location_accuracy"],
+            cfg["addGCPs"]["marker_location_accuracy"],
+            cfg["addGCPs"]["marker_location_accuracy"],
+        )
 
-    doc.chunk.marker_location_accuracy = (cfg["addGCPs"]["marker_location_accuracy"],cfg["addGCPs"]["marker_location_accuracy"],cfg["addGCPs"]["marker_location_accuracy"])
+    doc.chunk.marker_location_accuracy = (
+        cfg["addGCPs"]["marker_location_accuracy"],
+        cfg["addGCPs"]["marker_location_accuracy"],
+        cfg["addGCPs"]["marker_location_accuracy"],
+    )
     doc.chunk.marker_projection_accuracy = cfg["addGCPs"]["marker_projection_accuracy"]
 
     doc.save()
@@ -340,9 +404,9 @@ def align_photos(doc, log_file, run_id, cfg):
 
 
 def reset_region(doc):
-    '''
+    """
     Reset the region and make it much larger than the points; necessary because if points go outside the region, they get clipped when saving
-    '''
+    """
 
     doc.chunk.resetRegion()
     region_dims = doc.chunk.region.size
@@ -395,21 +459,29 @@ def filter_points_usgs_part1(doc, cfg):
     values.sort()
     thresh = values[int(len(values) * (1 - rec_thresh_percent / 100))]
     if thresh < rec_thresh_absolute:
-        thresh = rec_thresh_absolute  # don't throw away too many points if they're all good
+        thresh = (
+            rec_thresh_absolute  # don't throw away too many points if they're all good
+        )
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     fltr = Metashape.TiePoints.Filter()
     fltr.init(doc.chunk, Metashape.TiePoints.Filter.ProjectionAccuracy)
     values = fltr.values.copy()
     values.sort()
-    thresh = values[int(len(values) * (1- proj_thresh_percent / 100))]
+    thresh = values[int(len(values) * (1 - proj_thresh_percent / 100))]
     if thresh < proj_thresh_absolute:
-        thresh = proj_thresh_absolute  # don't throw away too many points if they're all good
+        thresh = (
+            proj_thresh_absolute  # don't throw away too many points if they're all good
+        )
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     fltr = Metashape.TiePoints.Filter()
     fltr.init(doc.chunk, Metashape.TiePoints.Filter.ReprojectionError)
@@ -420,14 +492,18 @@ def filter_points_usgs_part1(doc, cfg):
         thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     doc.save()
 
 
 def filter_points_usgs_part2(doc, cfg):
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     reproj_thresh_percent = cfg["filterPointsUSGS"]["reproj_thresh_percent"]
     reproj_thresh_absolute = cfg["filterPointsUSGS"]["reproj_thresh_absolute"]
@@ -441,34 +517,34 @@ def filter_points_usgs_part2(doc, cfg):
         thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
+    doc.chunk.optimizeCameras(
+        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
+    )
 
     doc.save()
 
 
 def classify_ground_points(doc, log_file, run_id, cfg):
 
-        # get a beginning time stamp for the next step
-        timer_a = time.time()
+    # get a beginning time stamp for the next step
+    timer_a = time.time()
 
-        doc.chunk.point_cloud.classifyGroundPoints(max_angle=cfg["classifyGroundPoints"]["max_angle"],
-                                                   max_distance=cfg["classifyGroundPoints"]["max_distance"],
-                                                   cell_size=cfg["classifyGroundPoints"]["cell_size"])
-        doc.save()
+    doc.chunk.point_cloud.classifyGroundPoints(
+        max_angle=cfg["classifyGroundPoints"]["max_angle"],
+        max_distance=cfg["classifyGroundPoints"]["max_distance"],
+        cell_size=cfg["classifyGroundPoints"]["cell_size"],
+    )
+    doc.save()
 
-        # get an ending time stamp for the previous step
-        timer_b = time.time()
+    # get an ending time stamp for the previous step
+    timer_b = time.time()
 
-        # calculate difference between end and start time to 1 decimal place
-        time_tot = diff_time(timer_b, timer_a)
+    # calculate difference between end and start time to 1 decimal place
+    time_tot = diff_time(timer_b, timer_a)
 
-        # record results to file
-        with open(log_file, 'a') as file:
-            file.write(sep.join(['Classify Ground Points', time_tot]) + '\n')
-
-
-
-
+    # record results to file
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Classify Ground Points", time_tot]) + "\n")
 
 
 def build_depth_map(doc, log_file, cfg):
@@ -620,22 +696,22 @@ def build_model(doc, log_file, run_id, cfg):
 
 
 def build_dem(doc, log_file, run_id, cfg):
-    '''
+    """
     Build end export DEM
-    '''
-    
+    """
+
     # classify ground points if specified
     if cfg["buildDem"]["classify_ground_points"]:
-    	classify_ground_points(doc, log_file, run_id, cfg)
+        classify_ground_points(doc, log_file, run_id, cfg)
 
     # get a beginning time stamp for the next step
     timer5a = time.time()
 
-    #prepping params for buildDem
+    # prepping params for buildDem
     projection = Metashape.OrthoProjection()
     projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
 
-    #prepping params for export
+    # prepping params for export
     compression = Metashape.ImageCompression()
     compression.tiff_big = cfg["buildDem"]["tiff_big"]
     compression.tiff_tiled = cfg["buildDem"]["tiff_tiled"]
@@ -643,30 +719,42 @@ def build_dem(doc, log_file, run_id, cfg):
 
     if (cfg["buildDem"]["type"] == "DSM") | (cfg["buildDem"]["type"] == "both"):
         # call without classes argument (Metashape then defaults to all classes)
-        doc.chunk.buildDem(source_data = Metashape.PointCloudData,
-                           subdivide_task = cfg["subdivide_task"],
-                           projection = projection)
-        output_file = os.path.join(cfg["output_path"], run_id + '_dsm.tif')
+        doc.chunk.buildDem(
+            source_data=Metashape.PointCloudData,
+            subdivide_task=cfg["subdivide_task"],
+            projection=projection,
+        )
+        output_file = os.path.join(cfg["output_path"], run_id + "_dsm.tif")
         if cfg["buildDem"]["export"]:
-            doc.chunk.exportRaster(path=output_file,
-                                   projection=projection,
-                                   nodata_value=cfg["buildDem"]["nodata"],
-                                   source_data=Metashape.ElevationData,
-                                   image_compression=compression)
+            doc.chunk.exportRaster(
+                path=output_file,
+                projection=projection,
+                nodata_value=cfg["buildDem"]["nodata"],
+                source_data=Metashape.ElevationData,
+                image_compression=compression,
+            )
     if (cfg["buildDem"]["type"] == "DTM") | (cfg["buildDem"]["type"] == "both"):
         # call with classes argument
-        doc.chunk.buildDem(source_data = Metashape.PointCloudData,
-                           classes = Metashape.PointClass.Ground,
-                           subdivide_task = cfg["subdivide_task"],
-                           projection = projection)
-        output_file = os.path.join(cfg["output_path"], run_id + '_dtm.tif')
+        doc.chunk.buildDem(
+            source_data=Metashape.PointCloudData,
+            classes=Metashape.PointClass.Ground,
+            subdivide_task=cfg["subdivide_task"],
+            projection=projection,
+        )
+        output_file = os.path.join(cfg["output_path"], run_id + "_dtm.tif")
         if cfg["buildDem"]["export"]:
-            doc.chunk.exportRaster(path=output_file,
-                                   projection=projection,
-                                   nodata_value=cfg["buildDem"]["nodata"],
-                                   source_data=Metashape.ElevationData,
-                                   image_compression=compression)
-    if (cfg["buildDem"]["type"] != "DTM") & (cfg["buildDem"]["type"] == "both") & (cfg["buildDem"]["type"] == "DSM"):
+            doc.chunk.exportRaster(
+                path=output_file,
+                projection=projection,
+                nodata_value=cfg["buildDem"]["nodata"],
+                source_data=Metashape.ElevationData,
+                image_compression=compression,
+            )
+    if (
+        (cfg["buildDem"]["type"] != "DTM")
+        & (cfg["buildDem"]["type"] == "both")
+        & (cfg["buildDem"]["type"] == "DSM")
+    ):
         raise ValueError("DEM type must be either 'DSM' or 'DTM' or 'both'")
 
     doc.save()
@@ -678,37 +766,41 @@ def build_dem(doc, log_file, run_id, cfg):
     time5 = diff_time(timer5b, timer5a)
 
     # record results to file
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Build DEM', time5])+'\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Build DEM", time5]) + "\n")
 
     return True
 
 
 def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
-    '''
+    """
     Helper function called by build_orthomosaics. build_export_orthomosaic builds and exports an ortho based on the current elevation data.
     build_orthomosaics sets the current elevation data and calls build_export_orthomosaic (one or more times depending on how many orthomosaics requested)
-    '''
+    """
 
     # get a beginning time stamp for the next step
     timer6a = time.time()
 
-    #prepping params for buildDem
+    # prepping params for buildDem
     projection = Metashape.OrthoProjection()
     projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
 
-    doc.chunk.buildOrthomosaic(surface_data=Metashape.ElevationData,
-                               blending_mode=cfg["buildOrthomosaic"]["blending"],
-                               fill_holes=cfg["buildOrthomosaic"]["fill_holes"],
-                               refine_seamlines=cfg["buildOrthomosaic"]["refine_seamlines"],
-                               subdivide_task=cfg["subdivide_task"],
-                               projection=projection)
+    doc.chunk.buildOrthomosaic(
+        surface_data=Metashape.ElevationData,
+        blending_mode=cfg["buildOrthomosaic"]["blending"],
+        fill_holes=cfg["buildOrthomosaic"]["fill_holes"],
+        refine_seamlines=cfg["buildOrthomosaic"]["refine_seamlines"],
+        subdivide_task=cfg["subdivide_task"],
+        projection=projection,
+    )
 
     doc.save()
 
     ## Export orthomosaic
     if cfg["buildOrthomosaic"]["export"]:
-        output_file = os.path.join(cfg["output_path"], run_id + '_ortho_' + file_ending + '.tif')
+        output_file = os.path.join(
+            cfg["output_path"], run_id + "_ortho_" + file_ending + ".tif"
+        )
 
         compression = Metashape.ImageCompression()
         compression.tiff_big = cfg["buildOrthomosaic"]["tiff_big"]
@@ -718,11 +810,13 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
         projection = Metashape.OrthoProjection()
         projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
 
-        doc.chunk.exportRaster(path=output_file,
-                               projection=projection,
-                               nodata_value=cfg["buildOrthomosaic"]["nodata"],
-                               source_data=Metashape.OrthomosaicData,
-                               image_compression=compression)
+        doc.chunk.exportRaster(
+            path=output_file,
+            projection=projection,
+            nodata_value=cfg["buildOrthomosaic"]["nodata"],
+            source_data=Metashape.OrthomosaicData,
+            image_compression=compression,
+        )
 
     # get an ending time stamp for the previous step
     timer6b = time.time()
@@ -731,16 +825,16 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
     time6 = diff_time(timer6b, timer6a)
 
     # record results to file
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Build Orthomosaic', time6]) + '\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Build Orthomosaic", time6]) + "\n")
 
     return True
 
 
 def build_orthomosaics(doc, log_file, run_id, cfg):
-    '''
+    """
     Build orthomosaic. This function just calculates the needed elevation data(s) and then calls build_export_orthomosaic to do the actual building and exporting. It does this multiple times if orthos based on multiple surfaces were requsted
-    '''
+    """
 
     # prep projection for export step below (in case export is enabled)
     projection = Metashape.OrthoProjection()
@@ -754,60 +848,65 @@ def build_orthomosaics(doc, log_file, run_id, cfg):
 
     # Import USGS DEM as surface for orthomosaic if specified
     if cfg["buildOrthomosaic"]["surface"] == "USGS":
-        path = os.path.join(cfg["photo_path"],cfg["buildOrthomosaic"]["usgs_dem_path"])
+        path = os.path.join(cfg["photo_path"], cfg["buildOrthomosaic"]["usgs_dem_path"])
         crs = Metashape.CoordinateSystem(cfg["buildOrthomosaic"]["usgs_dem_crs"])
-        doc.chunk.importRaster(path=path,
-                               crs=crs,
-                               raster_type=Metashape.ElevationData)
-        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending = "USGS")
+        doc.chunk.importRaster(path=path, crs=crs, raster_type=Metashape.ElevationData)
+        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="USGS")
     # Otherwise use Metashape point cloud to build elevation model
     # DTM: use ground points only
-    if (cfg["buildOrthomosaic"]["surface"] == "DTM") | (cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"):
-        doc.chunk.buildDem(source_data = Metashape.PointCloudData,
-                           classes=Metashape.PointClass.Ground,
-                           subdivide_task=cfg["subdivide_task"],
-                           projection=projection)
-        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending = "dtm")
+    if (cfg["buildOrthomosaic"]["surface"] == "DTM") | (
+        cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"
+    ):
+        doc.chunk.buildDem(
+            source_data=Metashape.PointCloudData,
+            classes=Metashape.PointClass.Ground,
+            subdivide_task=cfg["subdivide_task"],
+            projection=projection,
+        )
+        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dtm")
     # DSM: use all point classes
-    if (cfg["buildOrthomosaic"]["surface"] == "DSM") | (cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"):
-        doc.chunk.buildDem(source_data = Metashape.PointCloudData,
-                           subdivide_task=cfg["subdivide_task"],
-                           projection=projection)
-        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending = "dsm")
+    if (cfg["buildOrthomosaic"]["surface"] == "DSM") | (
+        cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"
+    ):
+        doc.chunk.buildDem(
+            source_data=Metashape.PointCloudData,
+            subdivide_task=cfg["subdivide_task"],
+            projection=projection,
+        )
+        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dsm")
 
     return True
 
 
 def export_report(doc, run_id, cfg):
-    '''
+    """
     Export report
-    '''
+    """
 
-    output_file = os.path.join(cfg["output_path"], run_id+'_report.pdf')
+    output_file = os.path.join(cfg["output_path"], run_id + "_report.pdf")
 
-    doc.chunk.exportReport(path = output_file)
+    doc.chunk.exportReport(path=output_file)
 
     return True
 
 
-def finish_run(log_file,config_file):
-    '''
+def finish_run(log_file, config_file):
+    """
     Finish run (i.e., write completed time to log)
-    '''
+    """
 
     # finish local results log and close it for the last time
-    with open(log_file, 'a') as file:
-        file.write(sep.join(['Run Completed', stamp_time()])+'\n')
+    with open(log_file, "a") as file:
+        file.write(sep.join(["Run Completed", stamp_time()]) + "\n")
 
     # open run configuration again. We can't just use the existing cfg file because its objects had already been converted to Metashape objects (they don't write well)
     with open(config_file) as file:
         config_full = yaml.safe_load(file)
 
     # write the run configuration to the log file
-    with open(log_file, 'a') as file:
+    with open(log_file, "a") as file:
         file.write("\n\n### CONFIGURATION ###\n")
-        documents = yaml.dump(config_full,file, default_flow_style=False)
+        documents = yaml.dump(config_full, file, default_flow_style=False)
         file.write("### END CONFIGURATION ###\n")
-
 
     return True

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -81,9 +81,7 @@ def project_setup(cfg, config_file):
     run_name = cfg["run_name"]
 
     if run_name == "from_config_filename":
-        file_basename = os.path.basename(
-            config_file
-        )  # extracts file base name from path
+        file_basename = os.path.basename(config_file)  # extracts file base name from path
         run_name, _ = os.path.splitext(file_basename)  # removes extension
 
     ## Project file example to make: "projectID_YYYYMMDDtHHMM-jobID.psx"
@@ -99,9 +97,7 @@ def project_setup(cfg, config_file):
     """
 
     # create a handle to the Metashape object
-    doc = (
-        Metashape.Document()
-    )  # When running via Metashape, can use: doc = Metashape.app.document
+    doc = Metashape.Document()  # When running via Metashape, can use: doc = Metashape.app.document
 
     # If specified, open existing project
     if cfg["load_project"] != "":
@@ -128,8 +124,7 @@ def project_setup(cfg, config_file):
         # write a line with the Metashape version
         file.write(sep.join(["Project", run_id]) + "\n")
         file.write(
-            sep.join(["Agisoft Metashape Professional Version", Metashape.app.version])
-            + "\n"
+            sep.join(["Agisoft Metashape Professional Version", Metashape.app.version]) + "\n"
         )
         # write a line with the date and time
         file.write(sep.join(["Processing started", stamp_time()]) + "\n")
@@ -153,9 +148,7 @@ def enable_and_log_gpu(log_file, cfg):
     while gpucount >= currentgpu:
         if gpustring != "":
             gpustring = gpustring + ", "
-        gpustring = (
-            gpustring + gpustringraw.split("name': '")[currentgpu].split("',")[0]
-        )
+        gpustring = gpustring + gpustringraw.split("name': '")[currentgpu].split("',")[0]
         currentgpu = currentgpu + 1
     # gpustring = gpustringraw.split("name': '")[1].split("',")[0]
     gpu_mask = Metashape.app.gpu_mask
@@ -182,9 +175,7 @@ def enable_and_log_gpu(log_file, cfg):
         Metashape.app.settings.setValue("main/gpu_enable_cuda", "0")
 
     # Set GPU multiplier to value specified (2 is default)
-    Metashape.app.settings.setValue(
-        "main/depth_max_gpu_multiplier", cfg["gpu_multiplier"]
-    )
+    Metashape.app.settings.setValue("main/depth_max_gpu_multiplier", cfg["gpu_multiplier"])
 
     return True
 
@@ -202,10 +193,7 @@ def add_photos(doc, cfg):
     photo_files = [
         x
         for x in b
-        if (
-            re.search("(.tif$)|(.jpg$)|(.TIF$)|(.JPG$)", x)
-            and (not re.search("dem_usgs.tif", x))
-        )
+        if (re.search("(.tif$)|(.jpg$)|(.TIF$)|(.JPG$)", x) and (not re.search("dem_usgs.tif", x)))
     ]
 
     ## Add them
@@ -282,23 +270,15 @@ def add_gcps(doc, cfg):
     """
 
     ## Tag specific pixels in specific images where GCPs are located
-    path = os.path.join(
-        cfg["photo_path"], "gcps", "prepared", "gcp_imagecoords_table.csv"
-    )
+    path = os.path.join(cfg["photo_path"], "gcps", "prepared", "gcp_imagecoords_table.csv")
     file = open(path)
     content = file.read().splitlines()
 
     for line in content:
         marker_label, camera_label, x_proj, y_proj = line.split(",")
-        if (
-            marker_label[0] == '"'
-        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
-            marker_label = marker_label[
-                1:-1
-            ]  # need to get it out of the two pairs of quotes
-        if (
-            camera_label[0] == '"'
-        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
+        if marker_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
+            marker_label = marker_label[1:-1]  # need to get it out of the two pairs of quotes
+        if camera_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
             camera_label = camera_label[1:-1]
 
         marker = get_marker(doc.chunk, marker_label)
@@ -323,12 +303,8 @@ def add_gcps(doc, cfg):
 
     for line in content:
         marker_label, world_x, world_y, world_z = line.split(",")
-        if (
-            marker_label[0] == '"'
-        ):  # if it's in quotes (from saving CSV in Excel), remove quotes
-            marker_label = marker_label[
-                1:-1
-            ]  # need to get it out of the two pairs of quotes
+        if marker_label[0] == '"':  # if it's in quotes (from saving CSV in Excel), remove quotes
+            marker_label = marker_label[1:-1]  # need to get it out of the two pairs of quotes
 
         marker = get_marker(doc.chunk, marker_label)
         if not marker:
@@ -428,9 +404,7 @@ def optimize_cameras(doc, run_id, cfg):
             doc.chunk.cameras[i].reference.enabled = False
 
     # Currently only optimizes the default parameters, which is not all possible parameters
-    doc.chunk.optimizeCameras(
-        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
-    )
+    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
 
     # optionally export, note this would override the export from align_cameras
     export_cameras(doc, run_id, cfg)
@@ -442,9 +416,7 @@ def optimize_cameras(doc, run_id, cfg):
 
 def filter_points_usgs_part1(doc, cfg):
 
-    doc.chunk.optimizeCameras(
-        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
-    )
+    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
 
     rec_thresh_percent = cfg["filterPointsUSGS"]["rec_thresh_percent"]
     rec_thresh_absolute = cfg["filterPointsUSGS"]["rec_thresh_absolute"]
@@ -459,14 +431,10 @@ def filter_points_usgs_part1(doc, cfg):
     values.sort()
     thresh = values[int(len(values) * (1 - rec_thresh_percent / 100))]
     if thresh < rec_thresh_absolute:
-        thresh = (
-            rec_thresh_absolute  # don't throw away too many points if they're all good
-        )
+        thresh = rec_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(
-        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
-    )
+    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
 
     fltr = Metashape.TiePoints.Filter()
     fltr.init(doc.chunk, Metashape.TiePoints.Filter.ProjectionAccuracy)
@@ -474,14 +442,10 @@ def filter_points_usgs_part1(doc, cfg):
     values.sort()
     thresh = values[int(len(values) * (1 - proj_thresh_percent / 100))]
     if thresh < proj_thresh_absolute:
-        thresh = (
-            proj_thresh_absolute  # don't throw away too many points if they're all good
-        )
+        thresh = proj_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(
-        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
-    )
+    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
 
     fltr = Metashape.TiePoints.Filter()
     fltr.init(doc.chunk, Metashape.TiePoints.Filter.ReprojectionError)
@@ -492,18 +456,14 @@ def filter_points_usgs_part1(doc, cfg):
         thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(
-        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
-    )
+    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
 
     doc.save()
 
 
 def filter_points_usgs_part2(doc, cfg):
 
-    doc.chunk.optimizeCameras(
-        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
-    )
+    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
 
     reproj_thresh_percent = cfg["filterPointsUSGS"]["reproj_thresh_percent"]
     reproj_thresh_absolute = cfg["filterPointsUSGS"]["reproj_thresh_absolute"]
@@ -517,9 +477,7 @@ def filter_points_usgs_part2(doc, cfg):
         thresh = reproj_thresh_absolute  # don't throw away too many points if they're all good
     fltr.removePoints(thresh)
 
-    doc.chunk.optimizeCameras(
-        adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"]
-    )
+    doc.chunk.optimizeCameras(adaptive_fitting=cfg["optimizeCameras"]["adaptive_fitting"])
 
     doc.save()
 
@@ -781,9 +739,7 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
 
     ## Export orthomosaic
     if cfg["buildOrthomosaic"]["export"]:
-        output_file = os.path.join(
-            cfg["output_path"], run_id + "_ortho_" + file_ending + ".tif"
-        )
+        output_file = os.path.join(cfg["output_path"], run_id + "_ortho_" + file_ending + ".tif")
 
         compression = Metashape.ImageCompression()
         compression.tiff_big = cfg["buildOrthomosaic"]["tiff_big"]

--- a/python/read_yaml.py
+++ b/python/read_yaml.py
@@ -9,26 +9,33 @@ import Metashape
 
 
 def convert_objects(a_dict):
-    '''
+    """
     Convert strings that refer to metashape objects (e.g. "Metashape.MoasicBlending") into metashape objects
 
     Based on
     https://stackoverflow.com/a/25896596/237354
-    '''
+    """
     for k, v in a_dict.items():
         if not isinstance(v, dict):
             if isinstance(v, str):
                 # TODO look for Metashape.
-                if v and 'Metashape' in v and not ('path' in k) and not ('project' in k) and not ('name' in k):    # allow "path" and "project" and "name" keys (e.g. "photoset_path" and "run_name") from YAML to include "Metashape" (e.g., Metashape in the filename)
+                if (
+                    v
+                    and "Metashape" in v
+                    and not ("path" in k)
+                    and not ("project" in k)
+                    and not ("name" in k)
+                ):  # allow "path" and "project" and "name" keys (e.g. "photoset_path" and "run_name") from YAML to include "Metashape" (e.g., Metashape in the filename)
                     a_dict[k] = eval(v)
             elif isinstance(v, list):
                 # TODO skip if no item have metashape
-                a_dict[k] =  [eval(item) for item in v if("Metashape" in item)]
+                a_dict[k] = [eval(item) for item in v if ("Metashape" in item)]
         else:
             convert_objects(v)
 
+
 def read_yaml(yml_path):
-    with open(yml_path,'r') as ymlfile:
+    with open(yml_path, "r") as ymlfile:
         cfg = yaml.load(ymlfile, Loader=yaml.SafeLoader)
 
     # TODO: wrap in a Try to catch errors
@@ -36,24 +43,25 @@ def read_yaml(yml_path):
 
     return cfg
 
+
 # For debugging when running this script directly:
 if __name__ == "__main__":
 
     yml_path = "config/example.yml"
     cfg = read_yaml(yml_path)
-    #with open("config/example.yml",'r') as ymlfile:
+    # with open("config/example.yml",'r') as ymlfile:
     #    cfg = yaml.load(ymlfile)
 
-    #catch = convert_objects(cfg)
+    # catch = convert_objects(cfg)
 
     # Get a String value
-    Photo_path = cfg['Photo_path']
+    Photo_path = cfg["Photo_path"]
 
     # Get a True/False
-    GPU_use = cfg['GPU']['GPU_use']
+    GPU_use = cfg["GPU"]["GPU_use"]
 
     # Get a Num
-    GPU_num = cfg['GPU']['GPU_num']
+    GPU_num = cfg["GPU"]["GPU_num"]
 
     # Convert a to a Metashape Object
     accuracy = eval(cfg["matchPhotos"]["accuracy"])


### PR DESCRIPTION
This adds a `build_model` function that is similar to `build_point_cloud`. Since both functions need depth maps, I moved this into a separate `build_depth_map` function. Finally, I added simple export options. 

I use the `black` formatter on most of my projects and I included the result of this in the last commit. If we don't want to use this format, I'm happy to role it back and match the existing style as best I can. 