### PR TITLE
Option to use mesh as surface for DEM/ortho generation

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -42,7 +42,7 @@ gpu_multiplier: 2
 ## Parameter names here generally follow the parameter names of the Metashape functions.
 
 ### Whether to use image EXIF RTK flags to make image geospatial accuracy more precise. If enabled but photos don't have RTK data, will treat them as regular photos and use the nofix accuracy.
-use_rtk: True
+use_rtk: False
 fix_accuracy: 3 # Accuracy to set for photos that have a RTK fix, in units of the CRS
 nofix_accuracy: 25 # Accuracy to set for photos that have no fix, in units of the CRS
 
@@ -69,10 +69,10 @@ alignPhotos: # (Metashape: matchPhotos, alignCameras, (optionally) exportCameras
     generic_preselection: True # When matching photos, use a much-coarsened version of each photo to narrow down the potential neighbors to pair? Works well if the photos have high altitude above the surface and high overlap (e.g. a 120m nadir 90/90 overlap mission), but doesn't work well for low-altitude and/or highly oblique photos (e.g. a 80m 25deg pitch 80/80 overlap mission)
     reference_preselection: True # When matching photos, use the camera location data to narrow down the potential neighbors to pair?
     reference_preselection_mode: Metashape.ReferencePreselectionSource # When matching photos, use the camera location data to narrow down the potential neighbors to pair?
-    export: False # Export the camera locations
+    export: True # Export the camera locations
 
 filterPointsUSGS:
-    enabled: True
+    enabled: False
     rec_thresh_percent: 20
     rec_thresh_absolute: 15
     proj_thresh_percent: 30
@@ -83,7 +83,7 @@ filterPointsUSGS:
 optimizeCameras: # (Metashape: optimizeCameras)
     enabled: True
     adaptive_fitting: True # Should the camera lens model be fit at the same time as optimizing photos?
-    export: False # Export the camera locations, now updated from the initial alignment
+    export: True # Export the camera locations, now updated from the initial alignment
 
 buildDepthMaps: # (Metashape: buildDepthMaps)
     enabled: True
@@ -93,27 +93,31 @@ buildDepthMaps: # (Metashape: buildDepthMaps)
     max_neighbors: 60 # Maximum number of neighboring photos to use for estimating depth map. Higher numbers may increase accuracy but dramatically increase processing time.
 
 buildPointCloud: # (Metashape: buildPointCloud, (optionally) classifyGroundPoints, and exportPoints)
-    enabled: True
-    ## For build point cloud (buildPointCloud)
+    enabled: False
     keep_depth: True # If False, removes depth maps from project data after building point cloud
     max_neighbors: 60 # Maximum number of neighboring photos to use for estimating point cloud. Higher numbers may increase accuracy but dramatically increase processing time.
-    ## For ground point classification (classifyGroundPoints). Definitions here: https://www.agisoft.com/forum/index.php?topic=9328.0
     classify_ground_points: True # Should ground points be classified as a part of this step? Must be enabled (either here or in buildDem, below) if a digital terrain model (DTM) is needed either for orthomosaic or DTM export. Enabling here is an alternative to enabling as a component of buildDem (below). It depends on which stage you want the classification to be done at. If you already have a point cloud but it's unclassified, then don't do it as part of this stage as it would require computing the point cloud again.
-    ## For point cloud export (exportPoints)
     export: False # Whether to export point cloud file.
     classes: "ALL" # Point classes to export. Must be a list. Or can set to "ALL" to use all points. An example of a specific class is: Metashape.PointClass.Ground
 
-classifyGroundPoints: # (Metashape: classifyGroundPoints) # classify points, IF SPECIFIED as a component of buildPointCloud (above) or buildDem (below). Must be enabled (either here or in buldDem, below) if a digital terrain model (DTM) is needed either for orthomosaic or DTM export. 
+classifyGroundPoints: # (Metashape: classifyGroundPoints) # classify points, IF SPECIFIED as a component of buildPointCloud (above) or buildDem (below). Must be enabled (in either location) if a digital terrain model (DTM) is needed either for orthomosaic or DTM export. Definitions here: https://www.agisoft.com/forum/index.php?topic=9328.0
     max_angle: 15.0
     max_distance: 1.0
     cell_size: 50.0
 
+buildModel:
+    enabled: True
+    face_count: "Metashape.MediumFaceCount" # How many faces to use, Metashape.LowFaceCount, MediumFaceCount, HighFaceCount, CustomFaceCount
+    face_count_custom: 100000 # Only used if custom number of faces set (above).
+    export_local: True # Export the model in local coordinates
+    export_transform: False # Export the transform matrix for local model coords -> global coords
+    export_georeferenced: True # Export the georeferenced model. If there's no georeferencing it will be the same as local
+    export_extension: "ply" # Can be any supported 3D model extension
+
 buildDem: # (Metashape: buildDem, (optionally) classifyGroundPoints, exportRaster)
     enabled: True
     classify_ground_points: False # Should ground points be classified as part of this step? Note that an alternative is to calculate them as a part of buildPointCloud (above)
-    ## For building DEM (buildDem)
-    type: "both" # Options: "DSM" or "DTM" or "both". Type of DEM to export (digital surface model, digital terrain model, or both).
-    ## For exporting DEM (exportRaster)
+    surface: ["DTM-ptcloud", "DSM-ptcloud", "DSM-mesh"] # Options: "DTM-ptcloud", "DSM-ptcloud", and/or "DSM-mesh". Type of DEM to export and data to build it from (digital terrain model or digital surface model, and from point cloud or mesh)
     export: True # Whether to export DEM(s)
     tiff_big: True # Use BigTIFF format? Required for larger projects with large DEMs
     tiff_tiled: False # Use tiled TIFF? This is related to internal file architecture.
@@ -122,24 +126,12 @@ buildDem: # (Metashape: buildDem, (optionally) classifyGroundPoints, exportRaste
 
 buildOrthomosaic: # (Metashape: buildOrthomosaic, exportRaster)
     enabled: True
-    ## For building orthomosaic (buildOrthomosaic)
-    surface: "DSM" # The surface to build the orthomosaic onto. "DTM", "DSM", "USGS", or "DTMandDSM. DTM and DSM refer to elevation models built by Metashape (buildDem step above) and stored in the project. If USGS, you must use GCPs with accurate elevations (ideally extracted from the USGS DEM).
-    usgs_dem_path: "dem_usgs/dem_usgs.tif" # Path to USGS DEM for the project area. Needed if surface (parameter above) is "USGS".
-    usgs_dem_crs: "EPSG::4269" # CRS of the USGS DEM. Needed if surface (parameter above) is "USGS". For sample RGB photoset, crs is 4269 (Geographic NAD83)
+    surface: ["DTM-ptcloud", "DSM-ptcloud", "DSM-mesh", "Mesh"] # Options: "DTM-ptcloud", "DSM-ptcloud", "DSM-mesh", and/or "Mesh". The surface to build the orthomosaic onto. DTM and DSM refer to elevation models built by Metashape and must be configured to be computed via buildDem, above. Mesh refers to using the mesh model directly rather than first computing a DEM.
     blending: Metashape.MosaicBlending # Photo blending mode. Options include AverageBlending, MosaicBlending, MinBlending, MaxBlending, DisabledBlending
     fill_holes: True # Fill holes in orthomosaic where no photo data exist by interpolating?
     refine_seamlines: True # Use smart algorithm to identify photo seamlines where they will least distort.
-    ## For exporting orthomosaic (exportRaster)
-    export: True # Whether to export orthomosaic
+    export: True # Whether to export orthomosaic(s)
     tiff_big: True # Use BigTIFF format? Required for larger projects with large DEMs
-    tiff_tiled: False # Use tiled TIFF? This is related to internal file architecture.
+    tiff_tiled: True # Use tiled TIFF? This is related to internal file architecture. Tiled may be (semi-)equivalent to COG.
     nodata: -32767 # Value used to represent nodata.
     tiff_overviews: True # Include coarse-scale raster data in file for quick display in GIS.
-
-buildModel:
-    enabled: False
-    face_count: "Metashape.MediumFaceCount" # How many faces to use, Metashape.LowFaceCount, MediumFaceCount, HighFaceCount, CustomFaceCount
-    face_count_custom: 100000 # Only used if custom number of faces set (above).
-    export_local: True # Export the model in local coordinates
-    export_georeferenced: True # Export the georeferenced model. If there's no georeferencing it will be the same as local
-    export_extension: "ply" # Can be any supported 3D model extension

--- a/python/metashape_workflow.py
+++ b/python/metashape_workflow.py
@@ -71,11 +71,8 @@ if cfg["buildPointCloud"]["enabled"]:
 if cfg["buildModel"]["enabled"]:
     meta.build_model(doc, log, run_id, cfg)
 
-if cfg["buildDem"]["enabled"]:
-    meta.build_dem(doc, log, run_id, cfg)
-
-if cfg["buildOrthomosaic"]["enabled"]:
-    meta.build_orthomosaics(doc, log, run_id, cfg)
+# For this step, the check for whether it is enabled in the config happens inside the function, because there are two steps (DEM and ortho), each of which can be enabled independently
+meta.build_dem_orthomosaic(doc, log, run_id, cfg)
 
 meta.export_report(doc, run_id, cfg)
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -635,18 +635,21 @@ def build_model(doc, log_file, run_id, cfg):
         doc.chunk.crs = None
         doc.chunk.transform.matrix = None
 
-        output_file = os.path.join(
-            cfg["output_path"],
-            run_id + "_local_model_transform.csv",
-        )
         # Export the transform
-        with open(output_file, "w") as fileh:
-            # This is a row-major representation
-            transform_tuple = tuple(old_transform_matrix)
-            # Write each row in the the transform
-            for i in range(4):
-                fileh.write(", ".join(transform_tuple[i * 4 : (i + 1) * 4]))
+        if cfg["buildModel"]["export_transform"]:
+            output_file = os.path.join(
+                cfg["output_path"],
+                run_id + "_local_model_transform.csv",
+            )
 
+            with open(output_file, "w") as fileh:
+                # This is a row-major representation
+                transform_tuple = tuple(old_transform_matrix)
+                # Write each row in the the transform
+                for i in range(4):
+                    fileh.write(", ".join(str(transform_tuple[i * 4 : (i + 1) * 4])))
+
+        # Export the model
         output_file = os.path.join(
             cfg["output_path"],
             run_id + "_model_local." + cfg["buildModel"]["export_extension"],
@@ -659,7 +662,7 @@ def build_model(doc, log_file, run_id, cfg):
     return True
 
 
-def build_dem(doc, log_file, run_id, cfg):
+def build_dem_orthomosaic(doc, log_file, run_id, cfg):
     """
     Build end export DEM
     """
@@ -671,55 +674,77 @@ def build_dem(doc, log_file, run_id, cfg):
     # get a beginning time stamp for the next step
     timer5a = time.time()
 
-    # prepping params for buildDem
-    projection = Metashape.OrthoProjection()
-    projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
+    if (cfg["buildDem"]["enabled"]):
+        # prepping params for buildDem
+        projection = Metashape.OrthoProjection()
+        projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
 
-    # prepping params for export
-    compression = Metashape.ImageCompression()
-    compression.tiff_big = cfg["buildDem"]["tiff_big"]
-    compression.tiff_tiled = cfg["buildDem"]["tiff_tiled"]
-    compression.tiff_overviews = cfg["buildDem"]["tiff_overviews"]
+        # prepping params for export
+        compression = Metashape.ImageCompression()
+        compression.tiff_big = cfg["buildDem"]["tiff_big"]
+        compression.tiff_tiled = cfg["buildDem"]["tiff_tiled"]
+        compression.tiff_overviews = cfg["buildDem"]["tiff_overviews"]
 
-    if (cfg["buildDem"]["type"] == "DSM") | (cfg["buildDem"]["type"] == "both"):
-        # call without classes argument (Metashape then defaults to all classes)
-        doc.chunk.buildDem(
-            source_data=Metashape.PointCloudData,
-            subdivide_task=cfg["subdivide_task"],
-            projection=projection,
-        )
-        output_file = os.path.join(cfg["output_path"], run_id + "_dsm.tif")
-        if cfg["buildDem"]["export"]:
-            doc.chunk.exportRaster(
-                path=output_file,
+        if ("DSM-ptcloud" in cfg["buildDem"]["surface"]):
+            # call without classes argument (Metashape then defaults to all classes)
+            doc.chunk.buildDem(
+                source_data=Metashape.PointCloudData,
+                subdivide_task=cfg["subdivide_task"],
                 projection=projection,
-                nodata_value=cfg["buildDem"]["nodata"],
-                source_data=Metashape.ElevationData,
-                image_compression=compression,
             )
-    if (cfg["buildDem"]["type"] == "DTM") | (cfg["buildDem"]["type"] == "both"):
-        # call with classes argument
-        doc.chunk.buildDem(
-            source_data=Metashape.PointCloudData,
-            classes=Metashape.PointClass.Ground,
-            subdivide_task=cfg["subdivide_task"],
-            projection=projection,
-        )
-        output_file = os.path.join(cfg["output_path"], run_id + "_dtm.tif")
-        if cfg["buildDem"]["export"]:
-            doc.chunk.exportRaster(
-                path=output_file,
+            output_file = os.path.join(cfg["output_path"], run_id + "_dsm-ptcloud.tif")
+            if cfg["buildDem"]["export"]:
+                doc.chunk.exportRaster(
+                    path=output_file,
+                    projection=projection,
+                    nodata_value=cfg["buildDem"]["nodata"],
+                    source_data=Metashape.ElevationData,
+                    image_compression=compression,
+                )
+                if cfg["buildOrthomosaic"]["enabled"] and "DSM-ptcloud" in cfg["buildOrthomosaic"]["surface"]:
+                    build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dsm-ptcloud")
+        if ("DTM-ptcloud" in cfg["buildDem"]["surface"]):
+            # call with classes argument
+            doc.chunk.buildDem(
+                source_data=Metashape.PointCloudData,
+                classes=Metashape.PointClass.Ground,
+                subdivide_task=cfg["subdivide_task"],
                 projection=projection,
-                nodata_value=cfg["buildDem"]["nodata"],
-                source_data=Metashape.ElevationData,
-                image_compression=compression,
             )
-    if (
-        (cfg["buildDem"]["type"] != "DTM")
-        & (cfg["buildDem"]["type"] == "both")
-        & (cfg["buildDem"]["type"] == "DSM")
-    ):
-        raise ValueError("DEM type must be either 'DSM' or 'DTM' or 'both'")
+            output_file = os.path.join(cfg["output_path"], run_id + "_dtm-ptcloud.tif")
+            if cfg["buildDem"]["export"]:
+                doc.chunk.exportRaster(
+                    path=output_file,
+                    projection=projection,
+                    nodata_value=cfg["buildDem"]["nodata"],
+                    source_data=Metashape.ElevationData,
+                    image_compression=compression,
+                )
+                if cfg["buildOrthomosaic"]["enabled"] and "DTM-ptcloud" in cfg["buildOrthomosaic"]["surface"]:
+                    build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dtm-ptcloud")
+
+        if ("DSM-mesh" in cfg["buildDem"]["surface"]):
+            # call with classes argument
+            doc.chunk.buildDem(
+                source_data=Metashape.ModelData,
+                subdivide_task=cfg["subdivide_task"],
+                projection=projection,
+            )
+            output_file = os.path.join(cfg["output_path"], run_id + "_dsm-mesh.tif")
+            if cfg["buildDem"]["export"]:
+                doc.chunk.exportRaster(
+                    path=output_file,
+                    projection=projection,
+                    nodata_value=cfg["buildDem"]["nodata"],
+                    source_data=Metashape.ElevationData,
+                    image_compression=compression,
+                )
+                if cfg["buildOrthomosaic"]["enabled"] and "DSM-mesh" in cfg["buildOrthomosaic"]["surface"]:
+                    build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dtm-ptcloud")
+
+    # Building an orthomosaic from the mesh does not require a DEM, so this is done separately, independent of any DEM building
+    if (cfg["buildOrthomosaic"]["enabled"] and "Mesh" in cfg["buildOrthomosaic"]["surface"]):
+        build_export_orthomosaic(doc, log_file, run_id, cfg, from_mesh = True, file_ending="mesh")
 
     doc.save()
 
@@ -736,10 +761,10 @@ def build_dem(doc, log_file, run_id, cfg):
     return True
 
 
-def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
+def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending, from_mesh = False):
     """
-    Helper function called by build_orthomosaics. build_export_orthomosaic builds and exports an ortho based on the current elevation data.
-    build_orthomosaics sets the current elevation data and calls build_export_orthomosaic (one or more times depending on how many orthomosaics requested)
+    Helper function called by build_dem_orthomosaic. build_export_orthomosaic builds and exports an ortho based on the current elevation data.
+    build_dem_orthomosaic sets the current elevation data and calls build_export_orthomosaic (one or more times depending on how many orthomosaics requested)
     """
 
     # get a beginning time stamp for the next step
@@ -749,8 +774,13 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
     projection = Metashape.OrthoProjection()
     projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
 
+    if from_mesh:
+        surface_data = Metashape.ModelData
+    else:
+        surface_data = Metashape.ElevationData
+
     doc.chunk.buildOrthomosaic(
-        surface_data=Metashape.ElevationData,
+        surface_data=surface_data,
         blending_mode=cfg["buildOrthomosaic"]["blending"],
         fill_holes=cfg["buildOrthomosaic"]["fill_holes"],
         refine_seamlines=cfg["buildOrthomosaic"]["refine_seamlines"],
@@ -789,53 +819,6 @@ def build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending):
     # record results to file
     with open(log_file, "a") as file:
         file.write(sep.join(["Build Orthomosaic", time6]) + "\n")
-
-    return True
-
-
-def build_orthomosaics(doc, log_file, run_id, cfg):
-    """
-    Build orthomosaic. This function just calculates the needed elevation data(s) and then calls build_export_orthomosaic to do the actual building and exporting. It does this multiple times if orthos based on multiple surfaces were requsted
-    """
-
-    # prep projection for export step below (in case export is enabled)
-    projection = Metashape.OrthoProjection()
-    projection.crs = Metashape.CoordinateSystem(cfg["project_crs"])
-
-    # get a beginning time stamp for the next step
-    timer6a = time.time()
-
-    # what should the orthomosaic filename end in? e.g., DSM, DTM, USGS to indicate the surface it was built on
-    file_ending = cfg["buildOrthomosaic"]["surface"]
-
-    # Import USGS DEM as surface for orthomosaic if specified
-    if cfg["buildOrthomosaic"]["surface"] == "USGS":
-        path = os.path.join(cfg["photo_path"], cfg["buildOrthomosaic"]["usgs_dem_path"])
-        crs = Metashape.CoordinateSystem(cfg["buildOrthomosaic"]["usgs_dem_crs"])
-        doc.chunk.importRaster(path=path, crs=crs, raster_type=Metashape.ElevationData)
-        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="USGS")
-    # Otherwise use Metashape point cloud to build elevation model
-    # DTM: use ground points only
-    if (cfg["buildOrthomosaic"]["surface"] == "DTM") | (
-        cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"
-    ):
-        doc.chunk.buildDem(
-            source_data=Metashape.PointCloudData,
-            classes=Metashape.PointClass.Ground,
-            subdivide_task=cfg["subdivide_task"],
-            projection=projection,
-        )
-        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dtm")
-    # DSM: use all point classes
-    if (cfg["buildOrthomosaic"]["surface"] == "DSM") | (
-        cfg["buildOrthomosaic"]["surface"] == "DTMandDSM"
-    ):
-        doc.chunk.buildDem(
-            source_data=Metashape.PointCloudData,
-            subdivide_task=cfg["subdivide_task"],
-            projection=projection,
-        )
-        build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dsm")
 
     return True
 

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -655,9 +655,12 @@ def build_model(doc, log_file, run_id, cfg):
             run_id + "_model_local." + cfg["buildModel"]["export_extension"],
         )
         doc.chunk.exportModel(path=output_file)
+
         # Reset CRS and transform
         doc.chunk.crs = old_crs
         doc.chunk.transform.matrix = old_transform_matrix
+
+        doc.open(doc.path)
 
     return True
 
@@ -740,7 +743,7 @@ def build_dem_orthomosaic(doc, log_file, run_id, cfg):
                     image_compression=compression,
                 )
                 if cfg["buildOrthomosaic"]["enabled"] and "DSM-mesh" in cfg["buildOrthomosaic"]["surface"]:
-                    build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dtm-ptcloud")
+                    build_export_orthomosaic(doc, log_file, run_id, cfg, file_ending="dsm-mesh")
 
     # Building an orthomosaic from the mesh does not require a DEM, so this is done separately, independent of any DEM building
     if (cfg["buildOrthomosaic"]["enabled"] and "Mesh" in cfg["buildOrthomosaic"]["surface"]):

--- a/python/read_yaml.py
+++ b/python/read_yaml.py
@@ -28,8 +28,9 @@ def convert_objects(a_dict):
                 ):  # allow "path" and "project" and "name" keys (e.g. "photoset_path" and "run_name") from YAML to include "Metashape" (e.g., Metashape in the filename)
                     a_dict[k] = eval(v)
             elif isinstance(v, list):
-                # TODO skip if no item have metashape
-                a_dict[k] = [eval(item) for item in v if ("Metashape" in item)]
+                # skip if no item in list have metashape, else convert string to metashape object
+                if any("Metashape" in item for item in v):
+                    a_dict[k] = [eval(item) for item in v if ("Metashape" in item)]
         else:
             convert_objects(v)
 
@@ -40,7 +41,7 @@ def read_yaml(yml_path):
 
     # TODO: wrap in a Try to catch errors
     convert_objects(cfg)
-
+    
     return cfg
 
 


### PR DESCRIPTION
... instead of point cloud

With this update, there are 3 options for the data used DEM generation: `["DTM-ptcloud", "DSM-ptcloud", "DSM-mesh"]`
And 4 options for the surface used for orthomosaic generation: `["DTM-ptcloud", "DSM-ptcloud", "DSM-mesh", "Mesh"]`

It allows specifying the options desired for DEM and for ortho generation/export as lists in the config YAML.

This update also streamlines DEM creation so that it only happens once per surface type, rather than twice as before (once to make/save DEM and again to make/save orthomosaic). Now DEM and ortho generation happen in a combined function `build_dem_orthomosaic`.