### PR TITLE
Relabel images using absolute, not relative, image path

### DIFF
--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -212,7 +212,12 @@ def add_photos(doc, cfg):
             doc.chunk.addPhotos(photo_files, layout=Metashape.MultiplaneLayout, group = grp)
         else:
             doc.chunk.addPhotos(photo_files, group = grp)
-
+            
+    ## Need to change the label on each camera so that it includes the containing folder(s)
+    for camera in doc.chunk.cameras:
+        path = camera.photo.path
+        camera.label = path
+    
     if cfg["separate_calibration_per_path"] :
         # Assign a different (new) sensor (i.e. independent calibration) to each group of photos
         for grp in doc.chunk.camera_groups:

--- a/python/metashape_workflow_functions.py
+++ b/python/metashape_workflow_functions.py
@@ -212,16 +212,7 @@ def add_photos(doc, cfg):
             doc.chunk.addPhotos(photo_files, layout=Metashape.MultiplaneLayout, group = grp)
         else:
             doc.chunk.addPhotos(photo_files, group = grp)
-            
-    ## Need to change the label on each camera so that it includes the containing folder(s)
-    for camera in doc.chunk.cameras:
-        path = camera.photo.path
-        # remove the base imagery dir from this string
-        rel_path = path.replace(cfg["photo_path"], "")
-        # if it starts with a '/', remove it
-        newlabel = re.sub("^/", "", rel_path)
-        camera.label = newlabel
-    
+
     if cfg["separate_calibration_per_path"] :
         # Assign a different (new) sensor (i.e. independent calibration) to each group of photos
         for grp in doc.chunk.camera_groups:


### PR DESCRIPTION
This is a quick fix so that the new "list of image folders" feature (#22) works. Relative paths could be brought back, will just take some attention to ensure that cameras are being relabeled properly based on the list of paths provided in the config.yml. However, absolute paths may sufficient as they could be relativized in post-processing.